### PR TITLE
Remove JWT decode fallback in session middleware

### DIFF
--- a/lib/middleware/withSession.ts
+++ b/lib/middleware/withSession.ts
@@ -1,11 +1,8 @@
 import { NextApiRequest, NextApiResponse, NextApiHandler } from 'next'
 import jwt from 'jsonwebtoken'
-import axios from 'axios'
 
-const PUBLIC_KEY = process.env.IDM_PUBLIC_KEY?.replace(/\n/g, '\n') || ''
+const PUBLIC_KEY = process.env.IDM_PUBLIC_KEY?.replace(/\\n/g, '\n') || ''
 const HAS_PUBLIC_KEY = !!(PUBLIC_KEY && PUBLIC_KEY.trim())
-
-const USER_INFO_URL = process.env.IDM_USER_INFO_URL || 'http://localhost:8080/api/users'
 
 export interface AuthenticatedRequest extends NextApiRequest {
   user?: any
@@ -18,29 +15,18 @@ export function withSession(handler: NextApiHandler) {
       return res.status(401).json({ error: 'Unauthorized' })
     }
 
-    try {
-      if (HAS_PUBLIC_KEY) {
-        const decoded = jwt.verify(token, PUBLIC_KEY, { algorithms: ['RS256'] }) as any
-        req.user = decoded
-        return handler(req, res)
-      }
-      throw new Error('NO_PUBLIC_KEY')
-    } catch {
-      // Fallback: decode without verify so we can read client_id/authorities
-      const decoded = jwt.decode(token) as any
-      if (decoded && (!decoded.exp || decoded.exp * 1000 > Date.now())) {
-        // Your token looks like: { client_id, authorities, exp, ... }
-        req.user = {
-          client_id: decoded.client_id,
-          authorities: decoded.authorities,
-          exp: decoded.exp,
-          ...decoded,
-        }
-        return handler(req, res)
-      }
+    if (!HAS_PUBLIC_KEY) {
+      console.error('No public key available for JWT verification')
       return res.status(401).json({ error: 'Unauthorized' })
     }
 
-    return handler(req, res)
+    try {
+      const decoded = jwt.verify(token, PUBLIC_KEY, { algorithms: ['RS256'] }) as any
+      req.user = decoded
+      return handler(req, res)
+    } catch (err) {
+      console.error('JWT verification failed:', err)
+      return res.status(401).json({ error: 'Unauthorized' })
+    }
   }
 }


### PR DESCRIPTION
## Summary
- simplify session middleware by requiring JWT verification
- handle missing public key and verification errors with 401 responses
- drop unused imports and constants

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(requires configuration and did not run)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68993ee463c08322a4e577f8a2b8af55