### PR TITLE
Add 405 default response and tests for subscriptions API

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.0.0",
@@ -35,6 +36,7 @@
     "eslint-config-next": "13.5.6",
     "postcss": "^8.4.24",
     "tailwindcss": "^3.3.2",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "vitest": "^1.6.0"
   }
 }

--- a/pages/api/subscriptions/index.test.ts
+++ b/pages/api/subscriptions/index.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../../../lib/middleware/withSession', () => ({
+  withSession: (handler: any) => handler,
+}))
+
+vi.mock('../../../lib/db/client', () => ({
+  db: {},
+}))
+
+const handler = (await import('./index')).default
+
+function createRes() {
+  const res: any = {}
+  res.status = vi.fn().mockImplementation(function (code: number) {
+    res.statusCode = code
+    return res
+  })
+  res.json = vi.fn().mockImplementation(function (data: any) {
+    res.body = data
+    return res
+  })
+  return res
+}
+
+describe('subscriptions API method handling', () => {
+  ;['OPTIONS', 'PUT', 'DELETE'].forEach((method) => {
+    it(`returns 405 for ${method}`, async () => {
+      const req: any = { method, user: { client_id: 'test-user' } }
+      const res = createRes()
+      await handler(req, res)
+      expect(res.status).toHaveBeenCalledWith(405)
+      expect(res.json).toHaveBeenCalledWith({ error: 'Method not allowed' })
+    })
+  })
+})

--- a/pages/api/subscriptions/index.ts
+++ b/pages/api/subscriptions/index.ts
@@ -32,4 +32,6 @@ export default withSession(async function handler(req: AuthenticatedRequest, res
         const items = await db.select().from(subscriptions).where(eq(subscriptions.ownerId, ownerId))
         return res.status(200).json({ subscriptions: items })
     }
+
+    return res.status(405).json({ error: 'Method not allowed' })
 })


### PR DESCRIPTION
## Summary
- return 405 Method not allowed for unsupported requests on subscriptions endpoint
- test OPTIONS, PUT and DELETE to ensure 405 response
- add vitest test script

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68993eee6cc88322906903ce8e4fa0a4