### PR TITLE
chore: set cookie sameSite to lax

### DIFF
--- a/pages/api/login.ts
+++ b/pages/api/login.ts
@@ -32,9 +32,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
     const { access_token, expires_in } = response.data
 
+    // Use SameSite=Lax to help mitigate CSRF by not sending the cookie on
+    // cross-site subrequests while allowing top-level navigation.
     res.setHeader('Set-Cookie', cookieLib.serialize('token', access_token, {
       httpOnly: true,
       secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
       maxAge: expires_in,
       path: '/'
     }))


### PR DESCRIPTION
## Summary
- mitigate CSRF by setting login token cookie to SameSite=Lax
- explain SameSite CSRF mitigation choice in login API comment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68993efc9d988322b5304c49f44340c7